### PR TITLE
Add icon-allow-overlay in layout properties

### DIFF
--- a/project/terra_layer/style/__init__.py
+++ b/project/terra_layer/style/__init__.py
@@ -38,6 +38,7 @@ def get_paint_or_layout(field):
         "text-field",
         "text-font",
         "text-size",
+        "icon-allow-overlap",
         "text-allow-overlap",
         "fill-sort-key",
         "line-sort-key",


### PR DESCRIPTION
We need to add 'icon-allow-overlay' cause currently it is added to the "paint" properties of the style instead of the "layout" ones