### PR TITLE
Add piechart in generated legend shapes

### DIFF
--- a/project/terra_layer/style/utils.py
+++ b/project/terra_layer/style/utils.py
@@ -10,6 +10,7 @@ style_type_2_legend_shape = {
     "circle": "circle",
     "symbol": "symbol",
     "line": "line",
+    "piechart": "circle",
 }
 
 stroke_color_props = ["line_color", "stroke_color", "outline_color"]


### PR DESCRIPTION
By default, piechart layers are not known so their legends are generated as squares.