### PR TITLE
Add icon-image in variable style props

### DIFF
--- a/project/terra_layer/style/__init__.py
+++ b/project/terra_layer/style/__init__.py
@@ -25,6 +25,7 @@ def field_2_variation_type(field):
         or "opacity" in field
         or "intensity" in field
         or "size" in field
+        or "image" in field
     ):
         return "value"
     if "radius" in field:


### PR DESCRIPTION
I don't have the python skills to test that but this is what it should do :

Currently, when the admin sends a layer config (to `api/geolayer/<id>`) with this (only keps the minimal stuff for the example)  :
```json
{
	"main_style": {
		"map_style_type": "icon",
		"style": {
			"icon_image": {
				"analysis": "categorized",
				"categories": [
					{
						"name": "deuxième",
						"value": "icon-2"
					},
					{
						"name": "premier",
						"value": "icon-1"
					},
					{
						"name": "quatrième",
						"value": "icon-2"
					},
					{
						"name": "troisième",
						"value": "icon-1"
					}
				],
				"field": "name",
				"type": "variable",
			},
		},
		"type": "wizard",
	}
}
```

the map_style object (send back to the admin in `main_style.map_style` and the one sent to the front) returned is this :

```json
{
	"map_style": {
		"type": "symbol",
		"minzoom": 0,
		"maxzoom": 24,
	}
}
```

When we should have the icon_image style generated like this :
```json
{
	"layout": {
		"icon-image": [
			"match",
			[
				"get",
				"name"
			],
			"deuxième",
			"icon-2",
			"premier",
			"icon-1",
			"quatrième",
			"icon-2",
			"troisième",
			"icon-1",
			"icon-2"
		]
	}
}
```

If I understood everything, the icon-image prop is not added to map_style because `field_2_variation_type` returns nothing, so no condition of the ifs is true https://github.com/Terralego/TerraVisu/blob/260414a525d0c7484d7856696aefcc93dbee52f3/project/terra_layer/style/__init__.py#L99

When we want it to go there -> https://github.com/Terralego/TerraVisu/blob/260414a525d0c7484d7856696aefcc93dbee52f3/project/terra_layer/style/__init__.py#L240

Hopefully I didn't miss anything and this should work (not sure about legend gen tho but that's less important)